### PR TITLE
script for bleu score eval on lasertagger prediction files

### DIFF
--- a/utils/bleu_eval.py
+++ b/utils/bleu_eval.py
@@ -1,0 +1,32 @@
+import sys
+import nltk
+
+
+def get_bleu_score_avg(filename):
+    """
+    Returns the average of the bleu scores
+    The file format is the one followed
+    in wikisplit prediction outputs:
+    source1 <::::> source2 \t output \t reference
+    """
+    data = open(filename, 'r').readlines()
+
+    lines = len(data)
+    avg = 0
+
+    for i in data:
+        splits = i.split('\t')
+        reference = splits[2].split()
+        output = splits[1].split()
+
+        bleu_score = nltk.translate.bleu_score.sentence_bleu([reference],
+                                                             output)
+
+        avg += bleu_score
+
+    return avg / lines
+
+
+if __name__ == '__main__':
+    bleu_avg = get_bleu_score_avg(sys.argv[1])
+    print("bleu avg: ", bleu_avg)

--- a/utils/test_bleu_eval.py
+++ b/utils/test_bleu_eval.py
@@ -1,0 +1,36 @@
+import os
+import unittest
+import bleu_eval
+
+
+class TestBLEUEval(unittest.TestCase):
+
+    def test_bleu_similar(self):
+        file = open("dummy_file.txt", 'w')
+        file.write("word \t word word word word \t word word word word \n")
+        file.close()
+
+        score = bleu_eval.get_bleu_score_avg("dummy_file.txt")
+
+        print(score)
+
+        self.assertEqual(score, 1)
+
+        os.remove("dummy_file.txt")
+
+    def test_bleu_dissimilar(self):
+        file = open("dummy_file.txt", 'w')
+        file.write("word \t word1 word1 word1 word1 \t word word word word \n")
+        file.close()
+
+        score = bleu_eval.get_bleu_score_avg("dummy_file.txt")
+
+        print(score)
+
+        self.assertEqual(score, 0)
+
+        os.remove("dummy_file.txt")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
```utils/bleu_eval.py``` is used to get get the BLEU score for the prediction files generated by the lasertagger. It takes the filename as a command line argument. 
```utils/test_bleu_eval.py``` has the unit tests for the script.