### PR TITLE
Changes to enable arbitrary word reordering in LaserTagger

### DIFF
--- a/models/lasertagger/README.md
+++ b/models/lasertagger/README.md
@@ -2,6 +2,10 @@ Source of lasertagger code: [https://github.com/google-research/lasertagger](htt
 
 Source of BERT code: [https://github.com/google-research/bert](https://github.com/google-research/bert)
 
+### The code here is a modified version of the source code.
+
+To use LaserTagger with arbitrary word reordering, follow the modified execution instructions in the following sections.
+
 # LaserTagger
 
 LaserTagger is a text-editing model which predicts a sequence of token-level
@@ -73,6 +77,9 @@ python phrase_vocabulary_optimization.py \
   --output_file=${OUTPUT_DIR}/label_map.txt
 ```
 
+Note: to use arbitrary word reordering, add ```--max_aribitrary_reordering_positions=<max_pos_numbers>``` where max_pos_numbers is the maximum number of words you expect to have in your rewritten sentence.
+
+
 Note that you can also set `max_input_examples` to a smaller value to get a
 reasonable vocabulary, but then you should sort the dataset rows in the case of
 WikiSplit. The rows are in an alphabetical order so taking first *k* of them
@@ -104,6 +111,9 @@ python preprocess_main.py \
     --vocab_file=${BERT_BASE_DIR}/vocab.txt \
     --output_arbitrary_targets_for_infeasible_examples=false
 ```
+
+Note: To use arbitrary word reordering, add ```--arbitrary_reordering=true``` and use ```--extra_tags_length=<num>``` to set the number of extra tags, which is 10 by default.
+
 
 ### 3. Model Training
 
@@ -180,6 +190,9 @@ python predict_main.py \
   --vocab_file=${BERT_BASE_DIR}/vocab.txt \
   --saved_model=${SAVED_MODEL_DIR}
 ```
+
+Note: To use arbitrary word reordering, add ```--arbitrary_reordering=true``` and use ```--extra_tags_length=<num>``` to set the number of extra tags, which is 10 by default.
+
 
 Note that the above will run inference with batch size of 1 so it's not optimal
 in terms of inference time.

--- a/models/lasertagger/bert_example.py
+++ b/models/lasertagger/bert_example.py
@@ -171,7 +171,7 @@ class BertExampleBuilder(object):
         if self._arbitrary_reordering:
             source_tokens = source_tokens + self._extra_tokens * [" . "]
             tags = tags + (len(source_tokens) -
-                           len(tags)) * [tagging.Tag("KEEP|EOS")]
+                           len(tags)) * [tagging.Tag("KEEP|<EOS>")]
 
         labels = [self._label_map[str(tag)] for tag in tags]
 

--- a/models/lasertagger/bert_example.py
+++ b/models/lasertagger/bert_example.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Build BERT Examples from text (source, target) pairs."""
 
 from __future__ import absolute_import
@@ -30,86 +29,87 @@ from typing import Mapping, MutableSequence, Optional, Sequence, Text
 
 
 class BertExample(object):
-  """Class for training and inference examples for BERT.
+    """Class for training and inference examples for BERT.
 
   Attributes:
     editing_task: The EditingTask from which this example was created. Needed
       when realizing labels predicted for this example.
     features: Feature dictionary.
   """
+    def __init__(self, input_ids, input_mask, segment_ids, labels, labels_mask,
+                 token_start_indices, task, default_label):
+        input_len = len(input_ids)
+        if not (input_len == len(input_mask) and input_len == len(segment_ids)
+                and input_len == len(labels)
+                and input_len == len(labels_mask)):
+            raise ValueError(
+                'All feature lists should have the same length ({})'.format(
+                    input_len))
 
-  def __init__(self, input_ids,
-               input_mask,
-               segment_ids, labels,
-               labels_mask,
-               token_start_indices,
-               task, default_label):
-    input_len = len(input_ids)
-    if not (input_len == len(input_mask) and input_len == len(segment_ids) and
-            input_len == len(labels) and input_len == len(labels_mask)):
-      raise ValueError(
-          'All feature lists should have the same length ({})'.format(
-              input_len))
+        self.features = collections.OrderedDict([
+            ('input_ids', input_ids),
+            ('input_mask', input_mask),
+            ('segment_ids', segment_ids),
+            ('labels', labels),
+            ('labels_mask', labels_mask),
+        ])
+        self._token_start_indices = token_start_indices
+        self.editing_task = task
+        self._default_label = default_label
 
-    self.features = collections.OrderedDict([
-        ('input_ids', input_ids),
-        ('input_mask', input_mask),
-        ('segment_ids', segment_ids),
-        ('labels', labels),
-        ('labels_mask', labels_mask),
-    ])
-    self._token_start_indices = token_start_indices
-    self.editing_task = task
-    self._default_label = default_label
-
-  def pad_to_max_length(self, max_seq_length, pad_token_id):
-    """Pad the feature vectors so that they all have max_seq_length.
+    def pad_to_max_length(self, max_seq_length, pad_token_id):
+        """Pad the feature vectors so that they all have max_seq_length.
 
     Args:
       max_seq_length: The length that features will have after padding.
       pad_token_id: input_ids feature is padded with this ID, other features
         with ID 0.
     """
-    pad_len = max_seq_length - len(self.features['input_ids'])
-    for key in self.features:
-      pad_id = pad_token_id if key == 'input_ids' else 0
-      self.features[key].extend([pad_id] * pad_len)
-      if len(self.features[key]) != max_seq_length:
-        raise ValueError('{} has length {} (should be {}).'.format(
-            key, len(self.features[key]), max_seq_length))
+        pad_len = max_seq_length - len(self.features['input_ids'])
+        for key in self.features:
+            pad_id = pad_token_id if key == 'input_ids' else 0
+            self.features[key].extend([pad_id] * pad_len)
+            if len(self.features[key]) != max_seq_length:
+                raise ValueError('{} has length {} (should be {}).'.format(
+                    key, len(self.features[key]), max_seq_length))
 
-  def to_tf_example(self):
-    """Returns this object as a tf.Example."""
+    def to_tf_example(self):
+        """Returns this object as a tf.Example."""
+        def int_feature(values):
+            return tf.train.Feature(int64_list=tf.train.Int64List(
+                value=list(values)))
 
-    def int_feature(values):
-      return tf.train.Feature(int64_list=tf.train.Int64List(value=list(values)))
+        tf_features = collections.OrderedDict([
+            (key, int_feature(val)) for key, val in self.features.items()
+        ])
+        return tf.train.Example(features=tf.train.Features(
+            feature=tf_features))
 
-    tf_features = collections.OrderedDict([
-        (key, int_feature(val)) for key, val in self.features.items()
-    ])
-    return tf.train.Example(features=tf.train.Features(feature=tf_features))
-
-  def get_token_labels(self):
-    """Returns labels/tags for the original tokens, not for wordpieces."""
-    labels = []
-    for idx in self._token_start_indices:
-      # For unmasked and untruncated tokens, use the label in the features, and
-      # for the truncated tokens, use the default label.
-      if (idx < len(self.features['labels']) and
-          self.features['labels_mask'][idx]):
-        labels.append(self.features['labels'][idx])
-      else:
-        labels.append(self._default_label)
-    return labels
+    def get_token_labels(self):
+        """Returns labels/tags for the original tokens, not for wordpieces."""
+        labels = []
+        for idx in self._token_start_indices:
+            # For unmasked and untruncated tokens, use the label in the features, and
+            # for the truncated tokens, use the default label.
+            if (idx < len(self.features['labels'])
+                    and self.features['labels_mask'][idx]):
+                labels.append(self.features['labels'][idx])
+            else:
+                labels.append(self._default_label)
+        return labels
 
 
 class BertExampleBuilder(object):
-  """Builder class for BertExample objects."""
-
-  def __init__(self, label_map, vocab_file,
-               max_seq_length, do_lower_case,
-               converter):
-    """Initializes an instance of BertExampleBuilder.
+    """Builder class for BertExample objects."""
+    def __init__(self,
+                 label_map,
+                 vocab_file,
+                 max_seq_length,
+                 do_lower_case,
+                 converter,
+                 arbitrary_reordering=True,
+                 extra_tokens=10):
+        """Initializes an instance of BertExampleBuilder.
 
     Args:
       label_map: Mapping from tags to tag IDs.
@@ -119,21 +119,22 @@ class BertExampleBuilder(object):
         uncased models and False for cased models.
       converter: Converter from text targets to tags.
     """
-    self._label_map = label_map
-    self._tokenizer = tokenization.FullTokenizer(vocab_file,
-                                                 do_lower_case=do_lower_case)
-    self._max_seq_length = max_seq_length
-    self._converter = converter
-    self._pad_id = self._get_pad_id()
-    self._keep_tag_id = self._label_map['KEEP']
+        self._label_map = label_map
+        self._tokenizer = tokenization.FullTokenizer(
+            vocab_file, do_lower_case=do_lower_case)
+        self._max_seq_length = max_seq_length
+        self._converter = converter
+        self._pad_id = self._get_pad_id()
+        self._keep_tag_id = self._label_map['KEEP']
+        self._arbitrary_reordering = arbitrary_reordering
+        self._extra_tokens = 10
 
-  def build_bert_example(
-      self,
-      sources,
-      target = None,
-      use_arbitrary_target_ids_for_infeasible_examples = False
-  ):
-    """Constructs a BERT Example.
+    def build_bert_example(
+            self,
+            sources,
+            target=None,
+            use_arbitrary_target_ids_for_infeasible_examples=False):
+        """Constructs a BERT Example.
 
     Args:
       sources: List of source texts.
@@ -146,51 +147,60 @@ class BertExampleBuilder(object):
       BertExample, or None if the conversion from text to tags was infeasible
       and use_arbitrary_target_ids_for_infeasible_examples == False.
     """
-    # Compute target labels.
-    task = tagging.EditingTask(sources)
-    if target is not None:
-      tags = self._converter.compute_tags(task, target)
-      if not tags:
-        if use_arbitrary_target_ids_for_infeasible_examples:
-          # Create a tag sequence [KEEP, DELETE, KEEP, DELETE, ...] which is
-          # unlikely to be predicted by chance.
-          tags = [tagging.Tag('KEEP') if i % 2 == 0 else tagging.Tag('DELETE')
-                  for i, _ in enumerate(task.source_tokens)]
+        # Compute target labels.
+        task = tagging.EditingTask(sources)
+        if target is not None:
+            tags = self._converter.compute_tags(task, target)
+            if not tags:
+                if use_arbitrary_target_ids_for_infeasible_examples:
+                    # Create a tag sequence [KEEP, DELETE, KEEP, DELETE, ...] which is
+                    # unlikely to be predicted by chance.
+                    tags = [
+                        tagging.Tag('KEEP') if i %
+                        2 == 0 else tagging.Tag('DELETE')
+                        for i, _ in enumerate(task.source_tokens)
+                    ]
+                else:
+                    return None
         else:
-          return None
-    else:
-      # If target is not provided, we set all target labels to KEEP.
-      tags = [tagging.Tag('KEEP') for _ in task.source_tokens]
-    labels = [self._label_map[str(tag)] for tag in tags]
+            # If target is not provided, we set all target labels to KEEP.
+            tags = [tagging.Tag('KEEP') for _ in task.source_tokens]
 
-    tokens, labels, token_start_indices = self._split_to_wordpieces(
-        task.source_tokens, labels)
+        source_tokens = task.source_tokens
+        if self._arbitrary_reordering:
+            source_tokens = source_tokens + self._extra_tokens * [" . "]
+            tags = tags + (len(source_tokens) -
+                           len(tags)) * [tagging.Tag("KEEP|EOS")]
 
-    tokens = self._truncate_list(tokens)
-    labels = self._truncate_list(labels)
+        labels = [self._label_map[str(tag)] for tag in tags]
 
-    input_tokens = ['[CLS]'] + tokens + ['[SEP]']
-    labels_mask = [0] + [1] * len(labels) + [0]
-    labels = [0] + labels + [0]
+        tokens, labels, token_start_indices = self._split_to_wordpieces(
+            source_tokens, labels)
 
-    input_ids = self._tokenizer.convert_tokens_to_ids(input_tokens)
-    input_mask = [1] * len(input_ids)
-    segment_ids = [0] * len(input_ids)
+        tokens = self._truncate_list(tokens)
+        labels = self._truncate_list(labels)
 
-    example = BertExample(
-        input_ids=input_ids,
-        input_mask=input_mask,
-        segment_ids=segment_ids,
-        labels=labels,
-        labels_mask=labels_mask,
-        token_start_indices=token_start_indices,
-        task=task,
-        default_label=self._keep_tag_id)
-    example.pad_to_max_length(self._max_seq_length, self._pad_id)
-    return example
+        input_tokens = ['[CLS]'] + tokens + ['[SEP]']
+        labels_mask = [0] + [1] * len(labels) + [0]
+        labels = [0] + labels + [0]
 
-  def _split_to_wordpieces(self, tokens, labels):
-    """Splits tokens (and the labels accordingly) to WordPieces.
+        input_ids = self._tokenizer.convert_tokens_to_ids(input_tokens)
+        input_mask = [1] * len(input_ids)
+        segment_ids = [0] * len(input_ids)
+
+        example = BertExample(input_ids=input_ids,
+                              input_mask=input_mask,
+                              segment_ids=segment_ids,
+                              labels=labels,
+                              labels_mask=labels_mask,
+                              token_start_indices=token_start_indices,
+                              task=task,
+                              default_label=self._keep_tag_id)
+        example.pad_to_max_length(self._max_seq_length, self._pad_id)
+        return example
+
+    def _split_to_wordpieces(self, tokens, labels):
+        """Splits tokens (and the labels accordingly) to WordPieces.
 
     Args:
       tokens: Tokens to be split.
@@ -200,26 +210,26 @@ class BertExampleBuilder(object):
       3-tuple with the split tokens, split labels, and the indices of the
       WordPieces that start a token.
     """
-    bert_tokens = []  # Original tokens split into wordpieces.
-    bert_labels = []  # Label for each wordpiece.
-    # Index of each wordpiece that starts a new token.
-    token_start_indices = []
-    for i, token in enumerate(tokens):
-      # '+ 1' is because bert_tokens will be prepended by [CLS] token later.
-      token_start_indices.append(len(bert_tokens) + 1)
-      pieces = self._tokenizer.tokenize(token)
-      bert_tokens.extend(pieces)
-      bert_labels.extend([labels[i]] * len(pieces))
-    return bert_tokens, bert_labels, token_start_indices
+        bert_tokens = []  # Original tokens split into wordpieces.
+        bert_labels = []  # Label for each wordpiece.
+        # Index of each wordpiece that starts a new token.
+        token_start_indices = []
+        for i, token in enumerate(tokens):
+            # '+ 1' is because bert_tokens will be prepended by [CLS] token later.
+            token_start_indices.append(len(bert_tokens) + 1)
+            pieces = self._tokenizer.tokenize(token)
+            bert_tokens.extend(pieces)
+            bert_labels.extend([labels[i]] * len(pieces))
+        return bert_tokens, bert_labels, token_start_indices
 
-  def _truncate_list(self, x):
-    """Returns truncated version of x according to the self._max_seq_length."""
-    # Save two slots for the first [CLS] token and the last [SEP] token.
-    return x[:self._max_seq_length - 2]
+    def _truncate_list(self, x):
+        """Returns truncated version of x according to the self._max_seq_length."""
+        # Save two slots for the first [CLS] token and the last [SEP] token.
+        return x[:self._max_seq_length - 2]
 
-  def _get_pad_id(self):
-    """Returns the ID of the [PAD] token (or 0 if it's not in the vocab)."""
-    try:
-      return self._tokenizer.convert_tokens_to_ids(['[PAD]'])[0]
-    except KeyError:
-      return 0
+    def _get_pad_id(self):
+        """Returns the ID of the [PAD] token (or 0 if it's not in the vocab)."""
+        try:
+            return self._tokenizer.convert_tokens_to_ids(['[PAD]'])[0]
+        except KeyError:
+            return 0

--- a/models/lasertagger/bert_example.py
+++ b/models/lasertagger/bert_example.py
@@ -127,7 +127,7 @@ class BertExampleBuilder(object):
         self._pad_id = self._get_pad_id()
         self._keep_tag_id = self._label_map['KEEP']
         self._arbitrary_reordering = arbitrary_reordering
-        self._extra_tokens = 10
+        self._extra_tokens = extra_tokens
 
     def build_bert_example(
             self,
@@ -148,7 +148,8 @@ class BertExampleBuilder(object):
       and use_arbitrary_target_ids_for_infeasible_examples == False.
     """
         # Compute target labels.
-        task = tagging.EditingTask(sources)
+        task = tagging.EditingTask(sources, self._arbitrary_reordering,
+                                   self._extra_tokens)
         if target is not None:
             tags = self._converter.compute_tags(task, target)
             if not tags:

--- a/models/lasertagger/configs/lasertagger_config_AR.json
+++ b/models/lasertagger/configs/lasertagger_config_AR.json
@@ -1,0 +1,19 @@
+{
+  "attention_probs_dropout_prob": 0.1,
+  "hidden_act": "gelu",
+  "hidden_dropout_prob": 0.1,
+  "hidden_size": 768,
+  "initializer_range": 0.02,
+  "intermediate_size": 3072,
+  "max_position_embeddings": 512,
+  "num_attention_heads": 12,
+  "num_hidden_layers": 12,
+  "type_vocab_size": 2,
+  "vocab_size": 28996,
+  "use_t2t_decoder": true,
+  "decoder_num_hidden_layers": 1,
+  "decoder_hidden_size": 768,
+  "decoder_num_attention_heads": 4,
+  "decoder_filter_size": 3072,
+  "use_full_attention": false
+}

--- a/models/lasertagger/phrase_vocabulary_optimization.py
+++ b/models/lasertagger/phrase_vocabulary_optimization.py
@@ -68,7 +68,11 @@ flags.DEFINE_integer(
     'Number of extra phrases that are not included in the vocabulary but for '
     'which we compute the coverage numbers. These numbers help determining '
     'whether the vocabulary size should have been larger.')
-
+flag.DEFINE_integer(
+    'max_aribitrary_reordering_positions', 0,
+    'Maximum number of positions in a target sentence '
+    'Used to generate the vocabulary to predict the position of a tag '
+    'arbitrary reordering is not enabled if this is 0, the default value.')
 
 def _compute_lcs(source, target):
   """Computes the Longest Common Subsequence (LCS).
@@ -278,6 +282,15 @@ def main(argv):
         # Write statistics.
         coverage = 100.0 * _count_covered_examples(matrix, i + 1) / num_examples
         stats_writer.write(f'{i+1}\t{count}\t{coverage:.2f}\t{phrase}\n')
+    
+    if FLAGS.max_aribitrary_reordering_positions != 0:
+      for i in range(FLAGS.max_aribitrary_reordering_positions):
+        writer.write(f'KEEP|{i}\n')
+        writer.write(f'DELETE|{i}\n')
+      
+      writer.write('KEEP|<EOS>\n')
+      writer.write('DELETE|<EOS>\n')
+      
   logging.info(f'Wrote tags to: {FLAGS.output_file}')
   logging.info(f'Wrote coverage numbers to: {statistics_file}')
 

--- a/models/lasertagger/predict_main.py
+++ b/models/lasertagger/predict_main.py
@@ -55,7 +55,7 @@ flags.DEFINE_bool(
     'models and False for cased models.')
 flags.DEFINE_bool('enable_swap_tag', True, 'Whether to enable the SWAP tag.')
 flags.DEFINE_string('saved_model', None, 'Path to an exported TF model.')
-flags.DEFINE_bool('arbitrary_reordering', True,
+flags.DEFINE_bool('arbitrary_reordering', False,
                   'Whether to allow arbitrary reordering.')
 flags.DEFINE_integer(
     'extra_tags_length', 10,

--- a/models/lasertagger/predict_main.py
+++ b/models/lasertagger/predict_main.py
@@ -37,9 +37,8 @@ flags.DEFINE_string(
     'input_file', None,
     'Path to the input file containing examples for which to compute '
     'predictions.')
-flags.DEFINE_enum(
-    'input_format', None, ['wikisplit', 'discofuse', 'wikifuse'],
-    'Format which indicates how to parse the input_file.')
+flags.DEFINE_enum('input_format', None, ['wikisplit', 'discofuse', 'wikifuse'],
+                  'Format which indicates how to parse the input_file.')
 flags.DEFINE_string(
     'output_file', None,
     'Path to the TSV file where the predictions are written to.')
@@ -56,42 +55,50 @@ flags.DEFINE_bool(
     'models and False for cased models.')
 flags.DEFINE_bool('enable_swap_tag', True, 'Whether to enable the SWAP tag.')
 flags.DEFINE_string('saved_model', None, 'Path to an exported TF model.')
+flags.DEFINE_bool('arbitrary_reordering', True,
+                  'Whether to allow arbitrary reordering.')
+flags.DEFINE_integer(
+    'extra_tags_length', 10,
+    'Number of extra tags to pad the source tokens array with')
 
 
 def main(argv):
-  if len(argv) > 1:
-    raise app.UsageError('Too many command-line arguments.')
-  flags.mark_flag_as_required('input_file')
-  flags.mark_flag_as_required('input_format')
-  flags.mark_flag_as_required('output_file')
-  flags.mark_flag_as_required('label_map_file')
-  flags.mark_flag_as_required('vocab_file')
-  flags.mark_flag_as_required('saved_model')
+    if len(argv) > 1:
+        raise app.UsageError('Too many command-line arguments.')
+    flags.mark_flag_as_required('input_file')
+    flags.mark_flag_as_required('input_format')
+    flags.mark_flag_as_required('output_file')
+    flags.mark_flag_as_required('label_map_file')
+    flags.mark_flag_as_required('vocab_file')
+    flags.mark_flag_as_required('saved_model')
 
-  label_map = utils.read_label_map(FLAGS.label_map_file)
-  converter = tagging_converter.TaggingConverter(
-      tagging_converter.get_phrase_vocabulary_from_label_map(label_map),
-      FLAGS.enable_swap_tag)
-  builder = bert_example.BertExampleBuilder(label_map, FLAGS.vocab_file,
-                                            FLAGS.max_seq_length,
-                                            FLAGS.do_lower_case, converter)
-  predictor = predict_utils.LaserTaggerPredictor(
-      tf.contrib.predictor.from_saved_model(FLAGS.saved_model), builder,
-      label_map)
+    label_map = utils.read_label_map(FLAGS.label_map_file)
+    converter = tagging_converter.TaggingConverter(
+        tagging_converter.get_phrase_vocabulary_from_label_map(label_map),
+        FLAGS.enable_swap_tag, FLAGS.arbitrary_reordering)
+    builder = bert_example.BertExampleBuilder(label_map, FLAGS.vocab_file,
+                                              FLAGS.max_seq_length,
+                                              FLAGS.do_lower_case, converter,
+                                              FLAGS.arbitrary_reordering,
+                                              FLAGS.extra_tags_length)
+    predictor = predict_utils.LaserTaggerPredictor(
+        tf.contrib.predictor.from_saved_model(FLAGS.saved_model), builder,
+        label_map)
 
-  num_predicted = 0
-  with tf.gfile.Open(FLAGS.output_file, 'w') as writer:
-    for i, (sources, target) in enumerate(utils.yield_sources_and_targets(
-        FLAGS.input_file, FLAGS.input_format)):
-      logging.log_every_n(
-          logging.INFO,
-          f'{i} examples processed, {num_predicted} converted to tf.Example.',
-          100)
-      prediction = predictor.predict(sources)
-      writer.write(f'{" ".join(sources)}\t{prediction}\t{target}\n')
-      num_predicted += 1
-  logging.info(f'{num_predicted} predictions saved to:\n{FLAGS.output_file}')
+    num_predicted = 0
+    with tf.gfile.Open(FLAGS.output_file, 'w') as writer:
+        for i, (sources, target) in enumerate(
+                utils.yield_sources_and_targets(FLAGS.input_file,
+                                                FLAGS.input_format)):
+            logging.log_every_n(
+                logging.INFO,
+                f'{i} examples processed, {num_predicted} converted to tf.Example.',
+                100)
+            prediction = predictor.predict(sources)
+            writer.write(f'{" ".join(sources)}\t{prediction}\t{target}\n')
+            num_predicted += 1
+    logging.info(f'{num_predicted} predictions saved to:\n{FLAGS.output_file}')
 
 
 if __name__ == '__main__':
-  app.run(main)
+    app.run(main)

--- a/models/lasertagger/tagging.py
+++ b/models/lasertagger/tagging.py
@@ -224,9 +224,14 @@ class EditingTask(object):
             else:
                 last_token = len(self.source_tokens)
             # Realize the source and fix casing.
-            realized_source = self._realize_sequence(
-                self.source_tokens[first_token:last_token],
-                tags[first_token:last_token])
+            if not self._arbitrary_reordering:
+                realized_source = self._realize_sequence(
+                    self.source_tokens[first_token:last_token],
+                    tags[first_token:last_token])
+            else:
+                realized_source = self._realize_sequence(
+                    self.source_tokens, tags
+                    )
             if outputs:
                 if outputs[0][-1:] in '.!?':
                     realized_source = self._first_char_to_upper(

--- a/models/lasertagger/tagging.py
+++ b/models/lasertagger/tagging.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Classes representing a tag and a text editing task.
 
 Tag corresponds to an edit operation, while EditingTask is a container for the
@@ -32,28 +31,27 @@ import utils
 
 
 class TagType(Enum):
-  """Base tag which indicates the type of an edit operation."""
-  # Keep the tagged token.
-  KEEP = 1
-  # Delete the tagged token.
-  DELETE = 2
-  # Keep the tagged token but swap the order of sentences. This tag is only
-  # applied if there are two source texts and the tag is applied to the last
-  # token of the first source. In other contexts, it's treated as KEEP.
-  SWAP = 3
+    """Base tag which indicates the type of an edit operation."""
+    # Keep the tagged token.
+    KEEP = 1
+    # Delete the tagged token.
+    DELETE = 2
+    # Keep the tagged token but swap the order of sentences. This tag is only
+    # applied if there are two source texts and the tag is applied to the last
+    # token of the first source. In other contexts, it's treated as KEEP.
+    SWAP = 3
 
 
 class Tag(object):
-  """Tag that corresponds to a token edit operation.
+    """Tag that corresponds to a token edit operation.
 
   Attributes:
     tag_type: TagType of the tag.
     added_phrase: A phrase that's inserted before the tagged token (can be
       empty).
   """
-
-  def __init__(self, tag):
-    """Constructs a Tag object by parsing tag to tag_type and added_phrase.
+    def __init__(self, tag):
+        """Constructs a Tag object by parsing tag to tag_type and added_phrase.
 
     Args:
       tag: String representation for the tag which should have the following
@@ -64,54 +62,64 @@ class Tag(object):
     Raises:
       ValueError: If <TagType> is invalid.
     """
-    if '|' in tag:
-      pos_pipe = tag.index('|')
-      tag_type, added_phrase = tag[:pos_pipe], tag[pos_pipe + 1:]
-    else:
-      tag_type, added_phrase = tag, ''
-    try:
-      self.tag_type = TagType[tag_type]
-    except KeyError:
-      raise ValueError(
-          'TagType should be KEEP, DELETE or SWAP, not {}'.format(tag_type))
-    self.added_phrase = added_phrase
+        if '|' in tag:
+            pos_pipe = tag.index('|')
+            tag_type, added_phrase = tag[:pos_pipe], tag[pos_pipe + 1:]
+        else:
+            tag_type, added_phrase = tag, ''
+        try:
+            self.tag_type = TagType[tag_type]
+        except KeyError:
+            raise ValueError(
+                'TagType should be KEEP, DELETE or SWAP, not {}'.format(
+                    tag_type))
+        self.added_phrase = added_phrase
 
-  def __str__(self):
-    if not self.added_phrase:
-      return self.tag_type.name
-    else:
-      return '{}|{}'.format(self.tag_type.name, self.added_phrase)
+    def __str__(self):
+        if not self.added_phrase:
+            return self.tag_type.name
+        else:
+            return '{}|{}'.format(self.tag_type.name, self.added_phrase)
 
 
 class EditingTask(object):
-  """Text-editing task.
+    """Text-editing task.
 
   Attributes:
     sources: Source texts.
     source_tokens: Tokens of the source texts concatenated into a single list.
     first_tokens: The indices of the first tokens of each source text.
   """
-
-  def __init__(self, sources):
-    """Initializes an instance of EditingTask.
+    def __init__(self, sources, arbitrary_reordering=True, extra_tags=10):
+        """Initializes an instance of EditingTask.
 
     Args:
       sources: A list of source strings. Typically contains only one string but
         for sentence fusion it contains two strings to be fused (whose order may
         be swapped).
     """
-    self.sources = sources
-    source_token_lists = [utils.get_token_list(text) for text in self.sources]
-    # Tokens of the source texts concatenated into a single list.
-    self.source_tokens = []
-    # The indices of the first tokens of each source text.
-    self.first_tokens = []
-    for token_list in source_token_lists:
-      self.first_tokens.append(len(self.source_tokens))
-      self.source_tokens.extend(token_list)
+        self.sources = sources
+        source_token_lists = [
+            utils.get_token_list(text) for text in self.sources
+        ]
+        # Tokens of the source texts concatenated into a single list.
+        self.source_tokens = []
+        # The indices of the first tokens of each source text.
+        self.first_tokens = []
+        for token_list in source_token_lists:
+            self.first_tokens.append(len(self.source_tokens))
+            self.source_tokens.extend(token_list)
 
-  def _realize_sequence(self, tokens, tags):
-    """Realizes output text corresponding to a single source text.
+        self._arbitrary_reordering = arbitrary_reordering
+
+        self._realize_sequence = self._realize_sequence_without_reordering
+        if arbitrary_reordering:
+            self._realize_sequence = self._realize_sequence_with_reordering
+
+        self._extra_tags = extra_tags
+
+    def _realize_sequence_without_reordering(self, tokens, tags):
+        """Realizes output text corresponding to a single source text.
 
     Args:
       tokens: Tokens of the source text.
@@ -120,30 +128,70 @@ class EditingTask(object):
     Returns:
       The realized text.
     """
-    output_tokens = []
-    for token, tag in zip(tokens, tags):
-      if tag.added_phrase:
-        output_tokens.append(tag.added_phrase)
-      if tag.tag_type in (TagType.KEEP, TagType.SWAP):
-        output_tokens.append(token)
-    return ' '.join(output_tokens)
+        output_tokens = []
+        for token, tag in zip(tokens, tags):
+            if tag.added_phrase:
+                output_tokens.append(tag.added_phrase)
+            if tag.tag_type in (TagType.KEEP, TagType.SWAP):
+                output_tokens.append(token)
+        return ' '.join(output_tokens)
 
-  def _first_char_to_upper(self, text):
-    """Upcases the first character of the text."""
-    try:
-      return text[0].upper() + text[1:]
-    except IndexError:
-      return text
+    def _get_pos(self, tag):
+        if '|' in tag and tag.split('|')[1].isnumeric():
+            return int(tag.split('|')[1])
+        return -1
 
-  def _first_char_to_lower(self, text):
-    """Lowcases the first character of the text."""
-    try:
-      return text[0].lower() + text[1:]
-    except IndexError:
-      return text
+    def _realize_sequence_with_reordering(self, tokens, tags):
+        """Realizes output text corresponding to a single source text,
+        taking into account word positions.
 
-  def realize_output(self, tags):
-    """Realize output text based on the source tokens and predicted tags.
+    Args:
+      tokens: Tokens of the source text.
+      tags: Tags indicating the edit operations.
+
+    Returns:
+      The realized text.
+    """
+        src_idx = 0
+        outputs = [] + 100 * [""]
+
+        for targ_idx, tag in enumerate(tags):
+            if src_idx >= len(tokens):
+                break
+
+            if tag == "KEEP|<EOS>":
+                continue
+            
+            source_token = tokens[src_idx]
+            pos = self._get_pos(tag)
+
+            if pos != -1:
+                outputs[pos] += "{0} ".format(source_token)
+
+            elif tag.startswith('KEEP|'):
+                outputs[targ_idx] += "{0} ".format(tag.split('|')[1])
+
+            if tag == "DELETE" or pos != -1:
+                src_idx += 1
+
+        return ''.join(outputs)
+
+    def _first_char_to_upper(self, text):
+        """Upcases the first character of the text."""
+        try:
+            return text[0].upper() + text[1:]
+        except IndexError:
+            return text
+
+    def _first_char_to_lower(self, text):
+        """Lowcases the first character of the text."""
+        try:
+            return text[0].lower() + text[1:]
+        except IndexError:
+            return text
+
+    def realize_output(self, tags):
+        """Realize output text based on the source tokens and predicted tags.
 
     Args:
       tags: Predicted tags (one for each token in `self.source_tokens`).
@@ -155,34 +203,38 @@ class EditingTask(object):
       ValueError: If the number of tags doesn't match the number of source
         tokens.
     """
-    if len(tags) != len(self.source_tokens):
-      raise ValueError('The number of tags ({}) should match the number of '
-                       'source tokens ({})'.format(
-                           len(tags), len(self.source_tokens)))
-    outputs = []  # Realized sources that are joined into the output text.
-    if (len(self.first_tokens) == 2 and
-        tags[self.first_tokens[1] - 1].tag_type == TagType.SWAP):
-      order = [1, 0]
-    else:
-      order = range(len(self.first_tokens))
-
-    for source_idx in order:
-      # Get the span of tokens for the source: [first_token, last_token).
-      first_token = self.first_tokens[source_idx]
-      if source_idx + 1 < len(self.first_tokens):
-        last_token = self.first_tokens[source_idx + 1]  # Not inclusive.
-      else:
-        last_token = len(self.source_tokens)
-      # Realize the source and fix casing.
-      realized_source = self._realize_sequence(
-          self.source_tokens[first_token:last_token],
-          tags[first_token:last_token])
-      if outputs:
-        if outputs[0][-1:] in '.!?':
-          realized_source = self._first_char_to_upper(realized_source)
+        if self._arbitrary_reordering or len(tags) != len(self.source_tokens):
+            raise ValueError(
+                'The number of tags ({}) should match the number of '
+                'source tokens ({})'.format(len(tags),
+                                            len(self.source_tokens)))
+        outputs = []  # Realized sources that are joined into the output text.
+        if (len(self.first_tokens) == 2
+                and tags[self.first_tokens[1] - 1].tag_type == TagType.SWAP):
+            order = [1, 0]
         else:
-          # Note that ideally we should also test here whether the first word is
-          # a proper noun or an abbreviation that should always be capitalized.
-          realized_source = self._first_char_to_lower(realized_source)
-      outputs.append(realized_source)
-    return ' '.join(outputs)
+            order = range(len(self.first_tokens))
+
+        for source_idx in order:
+            # Get the span of tokens for the source: [first_token, last_token).
+            first_token = self.first_tokens[source_idx]
+            if source_idx + 1 < len(self.first_tokens):
+                last_token = self.first_tokens[source_idx +
+                                               1]  # Not inclusive.
+            else:
+                last_token = len(self.source_tokens)
+            # Realize the source and fix casing.
+            realized_source = self._realize_sequence(
+                self.source_tokens[first_token:last_token],
+                tags[first_token:last_token])
+            if outputs:
+                if outputs[0][-1:] in '.!?':
+                    realized_source = self._first_char_to_upper(
+                        realized_source)
+                else:
+                    # Note that ideally we should also test here whether the first word is
+                    # a proper noun or an abbreviation that should always be capitalized.
+                    realized_source = self._first_char_to_lower(
+                        realized_source)
+            outputs.append(realized_source)
+        return ' '.join(outputs)

--- a/models/lasertagger/tagging_converter.py
+++ b/models/lasertagger/tagging_converter.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Conversion from training target text into target tags.
 
 The conversion algorithm from (source, target) pairs to (source, target_tags)
@@ -28,36 +27,40 @@ from __future__ import print_function
 import tagging
 import utils
 
-from typing import Iterable, Mapping, Sequence, Set, Text, Tuple
 
 
 class TaggingConverter(object):
-  """Converter from training target texts into tagging format."""
-
-  def __init__(self, phrase_vocabulary, do_swap=True):
-    """Initializes an instance of TaggingConverter.
+    """Converter from training target texts into tagging format."""
+    def __init__(self,
+                 phrase_vocabulary,
+                 do_swap=True,
+                 arbitrary_reordering=True):
+        """Initializes an instance of TaggingConverter.
 
     Args:
       phrase_vocabulary: Iterable of phrase vocabulary items (strings).
       do_swap: Whether to enable the SWAP tag.
     """
-    self._phrase_vocabulary = set(
-        phrase.lower() for phrase in phrase_vocabulary)
-    self._do_swap = do_swap
-    # Maximum number of tokens in an added phrase (inferred from the
-    # vocabulary).
-    self._max_added_phrase_length = 0
-    # Set of tokens that are part of a phrase in self.phrase_vocabulary.
-    self._token_vocabulary = set()
-    for phrase in self._phrase_vocabulary:
-      tokens = utils.get_token_list(phrase)
-      self._token_vocabulary |= set(tokens)
-      if len(tokens) > self._max_added_phrase_length:
-        self._max_added_phrase_length = len(tokens)
+        self._phrase_vocabulary = set(phrase.lower()
+                                      for phrase in phrase_vocabulary)
+        self._do_swap = do_swap
+        # Maximum number of tokens in an added phrase (inferred from the
+        # vocabulary).
+        self._max_added_phrase_length = 0
+        # Set of tokens that are part of a phrase in self.phrase_vocabulary.
+        self._token_vocabulary = set()
+        for phrase in self._phrase_vocabulary:
+            tokens = utils.get_token_list(phrase)
+            self._token_vocabulary |= set(tokens)
+            if len(tokens) > self._max_added_phrase_length:
+                self._max_added_phrase_length = len(tokens)
 
-  def compute_tags(self, task,
-                   target):
-    """Computes tags needed for converting the source into the target.
+        self._compute_single_tag = self._compute_single_tag_without_reordering
+        if arbitrary_reordering:
+            self._compute_single_tag = self._compute_single_tag_with_reordering
+
+    def compute_tags(self, task, target):
+        """Computes tags needed for converting the source into the target.
 
     Args:
       task: tagging.EditingTask that specifies the input.
@@ -67,25 +70,26 @@ class TaggingConverter(object):
       List of tagging.Tag objects. If the source couldn't be converted into the
       target via tagging, returns an empty list.
     """
-    target_tokens = utils.get_token_list(target.lower())
-    tags = self._compute_tags_fixed_order(task.source_tokens, target_tokens)
-    # If conversion fails, try to obtain the target after swapping the source
-    # order.
-    if not tags and len(task.sources) == 2 and self._do_swap:
-      swapped_task = tagging.EditingTask(task.sources[::-1])
-      tags = self._compute_tags_fixed_order(swapped_task.source_tokens,
-                                            target_tokens)
-      if tags:
-        tags = (tags[swapped_task.first_tokens[1]:] +
-                tags[:swapped_task.first_tokens[1]])
-        # We assume that the last token (typically a period) is never deleted,
-        # so we can overwrite the tag_type with SWAP (which keeps the token,
-        # moving it and the sentence it's part of to the end).
-        tags[task.first_tokens[1] - 1].tag_type = tagging.TagType.SWAP
-    return tags
+        target_tokens = utils.get_token_list(target.lower())
+        tags = self._compute_tags_fixed_order(task.source_tokens,
+                                              target_tokens)
+        # If conversion fails, try to obtain the target after swapping the source
+        # order.
+        if not tags and len(task.sources) == 2 and self._do_swap:
+            swapped_task = tagging.EditingTask(task.sources[::-1])
+            tags = self._compute_tags_fixed_order(swapped_task.source_tokens,
+                                                  target_tokens)
+            if tags:
+                tags = (tags[swapped_task.first_tokens[1]:] +
+                        tags[:swapped_task.first_tokens[1]])
+                # We assume that the last token (typically a period) is never deleted,
+                # so we can overwrite the tag_type with SWAP (which keeps the token,
+                # moving it and the sentence it's part of to the end).
+                tags[task.first_tokens[1] - 1].tag_type = tagging.TagType.SWAP
+        return tags
 
-  def _compute_tags_fixed_order(self, source_tokens, target_tokens):
-    """Computes tags when the order of sources is fixed.
+    def _compute_tags_fixed_order(self, source_tokens, target_tokens):
+        """Computes tags when the order of sources is fixed.
 
     Args:
       source_tokens: List of source tokens.
@@ -95,47 +99,58 @@ class TaggingConverter(object):
       List of tagging.Tag objects. If the source couldn't be converted into the
       target via tagging, returns an empty list.
     """
-    tags = [tagging.Tag('DELETE') for _ in source_tokens]
-    # Indices of the tokens currently being processed.
-    source_token_idx = 0
-    target_token_idx = 0
-    while target_token_idx < len(target_tokens):
-      tags[source_token_idx], target_token_idx = self._compute_single_tag(
-          source_tokens[source_token_idx], target_token_idx, target_tokens)
-      # If we're adding a phrase and the previous source token(s) were deleted,
-      # we could add the phrase before a previously deleted token and still get
-      # the same realized output. For example:
-      #    [DELETE, DELETE, KEEP|"what is"]
-      # and
-      #    [DELETE|"what is", DELETE, KEEP]
-      # Would yield the same realized output. Experimentally, we noticed that
-      # the model works better / the learning task becomes easier when phrases
-      # are always added before the first deleted token. Also note that in the
-      # current implementation, this way of moving the added phrase backward is
-      # the only way a DELETE tag can have an added phrase, so sequences like
-      # [DELETE|"What", DELETE|"is"] will never be created.
-      if tags[source_token_idx].added_phrase:
-        first_deletion_idx = self._find_first_deletion_idx(
-            source_token_idx, tags)
-        if first_deletion_idx != source_token_idx:
-          tags[first_deletion_idx].added_phrase = (
-              tags[source_token_idx].added_phrase)
-          tags[source_token_idx].added_phrase = ''
-      source_token_idx += 1
-      if source_token_idx >= len(tags):
-        break
+        tags = [tagging.Tag('DELETE') for _ in source_tokens]
+        # Indices of the tokens currently being processed.
+        source_token_idx = 0
+        target_token_idx = 0
+        while target_token_idx < len(target_tokens):
+            #tags[source_token_idx], target_token_idx = self._compute_single_tag_mod(
+            #    source_tokens[source_token_idx], target_token_idx, target_tokens, source_tokens)
+            tags[
+                source_token_idx], target_token_idx = self._compute_single_tag(
+                    source_tokens[source_token_idx], target_token_idx,
+                    target_tokens, source_tokens)
+            # If we're adding a phrase and the previous source token(s) were deleted,
+            # we could add the phrase before a previously deleted token and still get
+            # the same realized output. For example:
+            #    [DELETE, DELETE, KEEP|"what is"]
+            # and
+            #    [DELETE|"what is", DELETE, KEEP]
+            # Would yield the same realized output. Experimentally, we noticed that
+            # the model works better / the learning task becomes easier when phrases
+            # are always added before the first deleted token. Also note that in the
+            # current implementation, this way of moving the added phrase backward is
+            # the only way a DELETE tag can have an added phrase, so sequences like
+            # [DELETE|"What", DELETE|"is"] will never be created.
+            if tags[source_token_idx].added_phrase and not tags[
+                    source_token_idx].added_phrase.isnumeric():
+                first_deletion_idx = self._find_first_deletion_idx(
+                    source_token_idx, tags)
+                if first_deletion_idx != source_token_idx:
+                    tags[first_deletion_idx].added_phrase = (
+                        tags[source_token_idx].added_phrase)
+                    tags[source_token_idx].added_phrase = ''
+            source_token_idx += 1
+            if source_token_idx >= len(tags):
+                break
 
-    # If all target tokens have been consumed, we have found a conversion and
-    # can return the tags. Note that if there are remaining source tokens, they
-    # are already marked deleted when initializing the tag list.
-    if target_token_idx >= len(target_tokens):
-      return tags
-    return []
+        # If all target tokens have been consumed, we have found a conversion and
+        # can return the tags. Note that if there are remaining source tokens, they
+        # are already marked deleted when initializing the tag list.
+        print([
+            print("token: {0} - {1} ".format(source_tokens[i], str(label)))
+            for i, label in enumerate(tags)
+        ])
 
-  def _compute_single_tag(
-      self, source_token, target_token_idx,
-      target_tokens):
-    """Computes a single tag.
+        if target_token_idx >= len(target_tokens):
+            return tags
+
+        return []
+
+    def _compute_single_tag_without_reordering(self, source_token,
+                                               target_token_idx, target_tokens,
+                                               source_tokens):
+        """Computes a single tag.
 
     The tag may match multiple target tokens (via tag.added_phrase) so we return
     the next unmatched target token.
@@ -148,27 +163,56 @@ class TaggingConverter(object):
     Returns:
       A tuple with (1) the computed tag and (2) the next target_token_idx.
     """
-    source_token = source_token.lower()
-    target_token = target_tokens[target_token_idx].lower()
-    if source_token == target_token:
-      return tagging.Tag('KEEP'), target_token_idx + 1
+        source_token = source_token.lower()
+        target_token = target_tokens[target_token_idx].lower()
+        if source_token == target_token:
+            return tagging.Tag('KEEP'), target_token_idx + 1
 
-    added_phrase = ''
-    for num_added_tokens in range(1, self._max_added_phrase_length + 1):
-      if target_token not in self._token_vocabulary:
-        break
-      added_phrase += (' ' if added_phrase else '') + target_token
-      next_target_token_idx = target_token_idx + num_added_tokens
-      if next_target_token_idx >= len(target_tokens):
-        break
-      target_token = target_tokens[next_target_token_idx].lower()
-      if (source_token == target_token and
-          added_phrase in self._phrase_vocabulary):
-        return tagging.Tag('KEEP|' + added_phrase), next_target_token_idx + 1
-    return tagging.Tag('DELETE'), target_token_idx
+        added_phrase = ''
+        for num_added_tokens in range(1, self._max_added_phrase_length + 1):
+            if target_token not in self._token_vocabulary:
+                break
+            added_phrase += (' ' if added_phrase else '') + target_token
+            next_target_token_idx = target_token_idx + num_added_tokens
+            if next_target_token_idx >= len(target_tokens):
+                break
+            target_token = target_tokens[next_target_token_idx].lower()
+            if (source_token == target_token
+                    and added_phrase in self._phrase_vocabulary):
+                return tagging.Tag('KEEP|' +
+                                   added_phrase), next_target_token_idx + 1
+        return tagging.Tag('DELETE'), target_token_idx
 
-  def _find_first_deletion_idx(self, source_token_idx, tags):
-    """Finds the start index of a span of deleted tokens.
+    def _compute_single_tag_with_reordering(self, source_token,
+                                            target_token_idx, target_tokens,
+                                            source_tokens):
+        """Computes a single tag.
+
+    Max len : 200
+    """
+        source_token = source_token.lower()
+        while (target_token_idx < len(target_tokens) - 1
+               and target_tokens[target_token_idx].lower() == "null"):
+            target_token_idx += 1
+        target_token = target_tokens[target_token_idx].lower()
+
+        if target_token not in source_tokens:
+            if target_token in self._phrase_vocabulary:
+                return tagging.Tag("KEEP|" +
+                                   target_token), target_token_idx + 1
+            else:
+                return tagging.Tag("KEEP|DISCARD"), target_token_idx + 1
+
+        elif source_token in target_tokens:
+            idx = target_tokens.index(source_token)
+            target_tokens[idx] = "NULL"
+            return tagging.Tag("KEEP|" + str(idx)), target_token_idx
+
+        else:
+            return tagging.Tag("DELETE"), target_token_idx
+
+    def _find_first_deletion_idx(self, source_token_idx, tags):
+        """Finds the start index of a span of deleted tokens.
 
     If `source_token_idx` is preceded by a span of deleted tokens, finds the
     start index of the span. Otherwise, returns `source_token_idx`.
@@ -181,16 +225,15 @@ class TaggingConverter(object):
       The index of the first deleted token preceding `source_token_idx` or
       `source_token_idx` if there are no deleted tokens right before it.
     """
-    # Backtrack until the beginning of the tag sequence.
-    for idx in range(source_token_idx, 0, -1):
-      if tags[idx - 1].tag_type != tagging.TagType.DELETE:
-        return idx
-    return 0
+        # Backtrack until the beginning of the tag sequence.
+        for idx in range(source_token_idx, 0, -1):
+            if tags[idx - 1].tag_type != tagging.TagType.DELETE:
+                return idx
+        return 0
 
 
-def get_phrase_vocabulary_from_label_map(
-    label_map):
-  """Extract the set of all phrases from label map.
+def get_phrase_vocabulary_from_label_map(label_map):
+    """Extract the set of all phrases from label map.
 
   Args:
     label_map: Mapping from tags to tag IDs.
@@ -198,9 +241,9 @@ def get_phrase_vocabulary_from_label_map(
   Returns:
     Set of all phrases appearing in the label map.
   """
-  phrase_vocabulary = set()
-  for label in label_map.keys():
-    tag = tagging.Tag(label)
-    if tag.added_phrase:
-      phrase_vocabulary.add(tag.added_phrase)
-  return phrase_vocabulary
+    phrase_vocabulary = set()
+    for label in label_map.keys():
+        tag = tagging.Tag(label)
+        if tag.added_phrase:
+            phrase_vocabulary.add(tag.added_phrase)
+    return phrase_vocabulary

--- a/models/lasertagger/test_realizer_arbitrary_reordering.py
+++ b/models/lasertagger/test_realizer_arbitrary_reordering.py
@@ -1,0 +1,46 @@
+import unittest
+import tagging
+
+
+class TestRealizerArbitraryReordering(unittest.TestCase):
+    """
+        Tests for the realizer with arbitrary reordering
+        enabled.
+    """
+    def test_realize_output_in_order(self):
+        """
+            Test for when source tokens occur
+            in the same relative order in the 
+            target string
+        """
+        editing_task = tagging.EditingTask(["word1 word2 <::::> word3 "])
+
+        tags_str = ['KEEP|0', 'KEEP|1', 'KEEP|and', 'DELETE', 'KEEP|3']
+        tags = [tagging.Tag(tag) for tag in tags_str]
+
+        result = editing_task.realize_output([tags])
+
+        expected = "word1 word2 and word3 "
+
+        self.assertEqual(expected, result)
+
+    def test_realize_output_out_of_order(self):
+        """
+            Test for when the source tokens
+            do not occur in the same relative order
+            in the target string
+        """
+        editing_task = tagging.EditingTask(["word1 word2 <::::> word3 "])
+
+        tags_str = ['KEEP|1', 'KEEP|0', 'KEEP|and', 'DELETE', 'KEEP|3']
+        tags = [tagging.Tag(tag) for tag in tags_str]
+
+        result = editing_task.realize_output([tags])
+
+        expected = "word2 word1 and word3 "
+
+        self.assertEqual(expected, result)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/models/lasertagger/test_tagging_converter_arbitrary_reordering.py
+++ b/models/lasertagger/test_tagging_converter_arbitrary_reordering.py
@@ -1,0 +1,68 @@
+import unittest
+from tagging_converter import TaggingConverter
+import tagging
+
+
+class TestTaggingConverterArbitraryReordering(unittest.TestCase):
+    """
+        Tests for the tagging converter with arbitrary reordering
+        enabled.
+    """
+    def test_compute_tags_in_order(self):
+        """
+            Test for when source tokens occur
+            in the same relative order
+        """
+        dummy_phrase_vocabulary = ['and']
+        editing_task = tagging.EditingTask([" word1 word2 <::::> word3 "])
+        converter = TaggingConverter(dummy_phrase_vocabulary)
+
+        result = [
+            str(tag) for tag in converter.compute_tags(
+                editing_task, "word1 word2 and word3 ")
+        ]
+
+        expected = ['KEEP|0', 'KEEP|1', 'KEEP|and', 'DELETE', 'KEEP|3']
+
+        self.assertEqual(expected, result)
+
+    def test_compute_tags_out_of_order(self):
+        """
+            Test for when the source tokens
+            do not occur in the same relative order
+        """
+        dummy_phrase_vocabulary = ['and']
+        editing_task = tagging.EditingTask([" word1 word2 <::::> word3 "])
+        converter = TaggingConverter(dummy_phrase_vocabulary)
+
+        result = [
+            str(tag) for tag in converter.compute_tags(
+                editing_task, "word2 word1 and word3 ")
+        ]
+
+        expected = ['KEEP|1', 'KEEP|0', 'KEEP|and', 'DELETE', 'KEEP|3']
+
+        self.assertEqual(expected, result)
+
+    def test_compute_tags_infeasible(self):
+        """
+            Test for when the target cannot
+            be constructed by the given
+            edit vocab and source tokens
+        """
+        dummy_phrase_vocabulary = ['and']
+        editing_task = tagging.EditingTask([" word1 word2 <::::> word3 "])
+        converter = TaggingConverter(dummy_phrase_vocabulary)
+
+        result = [
+            str(tag) for tag in converter.compute_tags(
+                editing_task, "word2 word1 but word3 ")
+        ]
+
+        expected = []
+
+        self.assertEqual(expected, result)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
LaserTagger allows for flipping the order of source tokens in the target sentence only about the split between the two sentences. To possibly help improve performance on user query like data in indic languages, changes have been made to the LaserTagger source code to allow arbitrary reordering of words. 

This change is enabled by:

- appending the phrase vocabulary with additional tags to predict positions, along with tags that exist solely to pad the source tokens
- padding the source tokens with a predefined number of tokens so that when the number of target tokens exceeds the number of original source tokens, the target tokens can also be padded to reach the length of the padded source tokens. 
- a modified realizer that takes into account positions predicted, as well extra tags that add words from the edit vocabulary.

The instructions to make use of the changes mentioned above is included in the readme. 