### PR TITLE
added a readme file for lasertagger model with arbitrary word reordering

### DIFF
--- a/models/english_lasertagger/postprocess.py
+++ b/models/english_lasertagger/postprocess.py
@@ -2,9 +2,9 @@ import os
 import sys
 import json
 
-sys.path.append('./../utils/')
+sys.path.append('./../../utils/')
 sys.path.append('./models/utils/')
-import preprocess_utils as preprocess
+import preprocess_translate_data as preprocess
 import translate_utils as translate
 
 

--- a/models/english_lasertagger/preprocess.py
+++ b/models/english_lasertagger/preprocess.py
@@ -3,9 +3,9 @@ import json
 import sys
 import json
 
-sys.path.append('./../utils/')
+sys.path.append('./../../utils/')
 sys.path.append('./models/utils/')
-import preprocess_utils as preprocess
+import preprocess_translate_data as preprocess
 import translate_utils as translate
 
 def main(argv):

--- a/models/hindi_lasertagger_with_arbitrary_reordering/README.md
+++ b/models/hindi_lasertagger_with_arbitrary_reordering/README.md
@@ -1,0 +1,6 @@
+## Hindi Lasertagger with arbitrary word reordering
+
+Train Lasertagger with mBERT on data generated through the rule based system (to generate incoherent sentences) and the translated en-wikisplit dataset. 
+
+All the execution instructions are provided [here](https://github.com/googleinterns/contextual-query-rewrites/blob/master/models/lasertagger/README.md), please make sure to make note of the extra command line arguments to be used to enable arbitrary word reordering.
+

--- a/utils/test_translate_utils.py
+++ b/utils/test_translate_utils.py
@@ -32,6 +32,7 @@ class TestRawData(unittest.TestCase):
         self.assertEqual(data, expected)
 
     def test_translate_text_dir(self):
+        shutil.rmtree('./test_dummy_dir')
         os.mkdir('./test_dummy_dir')
         file = open("./test_dummy_dir/dummy_file.txt", 'w')
         file.write(" Ram \n")


### PR DESCRIPTION
The readme file also contains the data the model should be trained on. (data generated through rule based systems + translated en-wikisplit, to ensure lasertagger learns to deal with the incoherent data while making better use of the arbitrary reordering model) 
also fixed other issues with directory structure.